### PR TITLE
Fix tests on Windows OS

### DIFF
--- a/src/test/e2e/presents-report.ts
+++ b/src/test/e2e/presents-report.ts
@@ -1,3 +1,4 @@
+import {join} from 'path';
 import * as assert from 'assert';
 import {mock, when} from '../helpers/helper';
 import {EXT1_CHANGELOG, EXT2_CHANGELOG, EXT3_CHANGELOG, createExtensionContext, readTestDataFile} from '../helpers/extension-data';
@@ -9,9 +10,9 @@ import ExtensionStarter from '../../lib/extension-starter';
 describe('Presents the report', () => {
 
   const fileSystem = mock(FileSystem);
-  when(fileSystem.readFile('PATH_1/CHANGELOG.md')).thenResolve(EXT1_CHANGELOG);
-  when(fileSystem.readFile('PATH_2/CHANGELOG.md')).thenResolve(EXT2_CHANGELOG);
-  when(fileSystem.readFile('PATH_3/CHANGELOG.md')).thenResolve(EXT3_CHANGELOG);
+  when(fileSystem.readFile(join('PATH_1', 'CHANGELOG.md'))).thenResolve(EXT1_CHANGELOG);
+  when(fileSystem.readFile(join('PATH_2', 'CHANGELOG.md'))).thenResolve(EXT2_CHANGELOG);
+  when(fileSystem.readFile(join('PATH_3', 'CHANGELOG.md'))).thenResolve(EXT3_CHANGELOG);
 
   const vscode = createVsCode();
 

--- a/src/test/lib/content-provider.test.ts
+++ b/src/test/lib/content-provider.test.ts
@@ -1,3 +1,4 @@
+import {join} from 'path';
 import * as assert from 'assert';
 import {mock, when} from '../helpers/helper';
 
@@ -15,7 +16,7 @@ describe('ContentProvider', () => {
   const updatedExtensions = [new PreloadedExtension(extensionRaw, parseVersion('0.1.0'))];
 
   const fileSystem = mock(FileSystem);
-  when(fileSystem.readFile('PATH1/CHANGELOG.md')).thenReject(new Error('FILE_NOT_FOUND'));
+  when(fileSystem.readFile(join('PATH1', 'CHANGELOG.md'))).thenReject(new Error('FILE_NOT_FOUND'));
 
   const markdownReportGenerator = new MarkdownReportGeneratorFactory(fileSystem).create();
 

--- a/src/test/lib/markdown-report.test.ts
+++ b/src/test/lib/markdown-report.test.ts
@@ -1,3 +1,4 @@
+import {join} from 'path';
 import * as assert from 'assert';
 
 import {PreloadedExtension} from '../../lib/entities/extension';
@@ -20,11 +21,11 @@ type ExtensionSource = {
 
 describe('Markdown Report', () => {
   const fileSystem = mock(FileSystem);
-  when(fileSystem.readFile('PATH1/CHANGELOG.md')).thenResolve(VALID_1);
-  when(fileSystem.readFile('PATH2/CHANGELOG.md')).thenResolve(VALID_2);
-  when(fileSystem.readFile('PATH3/CHANGELOG.md')).thenResolve(INVALID_VERSION_FORMAT);
-  when(fileSystem.readFile('PATH4/CHANGELOG.md')).thenReject(new Error('FILE_NOT_FOUND'));
-  when(fileSystem.readFile('PATH5/CHANGELOG.md')).thenResolve(INVALID_HEADING);
+  when(fileSystem.readFile(join('PATH1','CHANGELOG.md'))).thenResolve(VALID_1);
+  when(fileSystem.readFile(join('PATH2','CHANGELOG.md'))).thenResolve(VALID_2);
+  when(fileSystem.readFile(join('PATH3','CHANGELOG.md'))).thenResolve(INVALID_VERSION_FORMAT);
+  when(fileSystem.readFile(join('PATH4','CHANGELOG.md'))).thenReject(new Error('FILE_NOT_FOUND'));
+  when(fileSystem.readFile(join('PATH5','CHANGELOG.md'))).thenResolve(INVALID_HEADING);
 
   const markdownReportGenerator = new MarkdownReportGeneratorFactory(fileSystem).create();
 


### PR DESCRIPTION
This PR contains the following:
* Fix (almost all) tests on Windows.

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td>

![image](https://user-images.githubusercontent.com/55841/189205010-886367c4-47aa-4757-a0b7-5c13d33d0280.png)
	<td>

![image](https://user-images.githubusercontent.com/55841/189205110-4e3ad903-dd39-4ef2-a522-d823d2cea976.png)

</table>

As you can see, one test is still failing. At some point I got it working and I have a feeling it's related to line-endings. Will investigate after this is merged, to get some flow going.