### PR TITLE
Run CI on master branch & PR

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,5 +1,9 @@
 name: CI build
-on: [push]
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
 jobs:
   ci-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I noticed that you already converted Travis CI over to GitHub Actions. Was about to propose it too.
One thing missing here is to also run CI on Pull Requests.