### PR TITLE
Add collapsible sections/details

### DIFF
--- a/src/lib/markdown-report-builder.ts
+++ b/src/lib/markdown-report-builder.ts
@@ -19,8 +19,14 @@ export default class MarkdownReportBuilder {
     return extensions
       .map(extension =>
         multiline(`
-        ## ${extension.displayName} \`${extension.id}\`
-        ${this.buildChangelog(extension)}`)
+        <details open>
+          <summary>
+
+          ## ${extension.displayName} \`${extension.id}\`
+          </summary>
+
+          ${this.buildChangelog(extension)}
+        </details>`)
       )
       .join('\n\n');
   }

--- a/src/lib/markdown-to-html-converter.ts
+++ b/src/lib/markdown-to-html-converter.ts
@@ -1,4 +1,4 @@
-const md = require('markdown-it')();
+const md = require('markdown-it')('commonmark');
 const multiline = require('multiline-string')();
 
 export default class MarkdownToHtmlConverter {
@@ -7,7 +7,7 @@ export default class MarkdownToHtmlConverter {
       <html lang="en">
         <head>
           <meta http-equiv="Content-Security-Policy"
-              content="default-src 'none'; img-src *; style-src 'sha256-cAWJpTizP2D7+19DP5Fc9XNkH3mSkp6VcpSqGNtMXbE='; script-src 'none';">
+              content="default-src 'none'; img-src *; style-src 'sha256-bBr7BPyvfaIoQLDEpYYF6kpvYqEjw2fHBHaVFrC7x1I='; script-src 'none';">
           <style>
             html {
               font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
@@ -87,6 +87,29 @@ export default class MarkdownToHtmlConverter {
             }
             .vscode-dark code {
               background-color: #4b4b4b;
+            }
+
+            details > summary {
+              list-style: none;
+              position: relative;
+              cursor: pointer;
+            }
+            details > summary::marker {
+              display: none;
+            }
+            details > summary::before {
+              content: "▼";
+              font-family: serif;
+              position: absolute;
+              left: 0;
+              top: 40%;
+              transform: translate(0, -50%) rotate(-90deg);
+            }
+            details[open] > summary:before {
+              transform: translate(0, -50%) rotate(0);
+            }
+            details > summary > * {
+              padding-left: 1.5rem;
             }
           </style>
         </head>

--- a/src/test/lib/content-provider.test.ts
+++ b/src/test/lib/content-provider.test.ts
@@ -27,8 +27,12 @@ describe('ContentProvider', () => {
     const expectation = multiline(`
         |  <body>
         |    <h1>Extension Updates</h1>
+        |<details open>
+        |  <summary>
         |<h2>EXT_NAME <code>ID</code></h2>
+        |  </summary>
         |<p>CHANGELOG.md not found</p>
+        |</details>
         |
         |  </body>`);
     assert.ok(html.includes(expectation));

--- a/src/test/lib/markdown-report.test.ts
+++ b/src/test/lib/markdown-report.test.ts
@@ -48,8 +48,13 @@ describe('Markdown Report', () => {
     await assertMarkdownReports([extension1, extension2], multiline(`
       # Extension Updates
 
-      ## EXT_NAME_1 \`EXT1\`
-      ### [1.0.0]
+      <details open>
+        <summary>
+
+        ## EXT_NAME_1 \`EXT1\`
+        </summary>
+
+        ### [1.0.0]
       #### Added
       - foo2
       - bar
@@ -57,11 +62,18 @@ describe('Markdown Report', () => {
       ### [0.9.0]
       #### Added
       - foo
+      </details>
 
-      ## EXT_NAME_2 \`EXT2\`
-      ### [0.1.0]
+      <details open>
+        <summary>
+
+        ## EXT_NAME_2 \`EXT2\`
+        </summary>
+
+        ### [0.1.0]
       #### Removed
       - baz
+      </details>
       `)
     );
   });
@@ -78,8 +90,14 @@ describe('Markdown Report', () => {
     await assertMarkdownReports([extension], multiline(`
       # Extension Updates
 
-      ## EXT_NAME_3 \`EXT3\`
-      Couldn't parse the changelog. [View it on Marketplace](https://marketplace.visualstudio.com/items/EXT3/changelog).
+      <details open>
+        <summary>
+
+        ## EXT_NAME_3 \`EXT3\`
+        </summary>
+
+        Couldn't parse the changelog. [View it on Marketplace](https://marketplace.visualstudio.com/items/EXT3/changelog).
+      </details>
       `)
     );
   });
@@ -96,8 +114,14 @@ describe('Markdown Report', () => {
     await assertMarkdownReports([extension], multiline(`
       # Extension Updates
 
-      ## EXT_NAME_4 \`EXT4\`
-      CHANGELOG.md not found
+      <details open>
+        <summary>
+
+        ## EXT_NAME_4 \`EXT4\`
+        </summary>
+
+        CHANGELOG.md not found
+      </details>
       `)
     );
   });
@@ -114,12 +138,18 @@ describe('Markdown Report', () => {
     await assertMarkdownReports([extension], multiline(`
       # Extension Updates
 
-      ## EXT_NAME_5 \`EXT5\`
-      ### [1.3.0]
+      <details open>
+        <summary>
+
+        ## EXT_NAME_5 \`EXT5\`
+        </summary>
+
+        ### [1.3.0]
       * foo
 
       #### Fixes:
       * bar
+      </details>
       `)
     );
   });

--- a/test-data/e2e/sample-report.html
+++ b/test-data/e2e/sample-report.html
@@ -1,7 +1,7 @@
 <html lang="en">
   <head>
     <meta http-equiv="Content-Security-Policy"
-        content="default-src 'none'; img-src *; style-src 'sha256-cAWJpTizP2D7+19DP5Fc9XNkH3mSkp6VcpSqGNtMXbE='; script-src 'none';">
+        content="default-src 'none'; img-src *; style-src 'sha256-bBr7BPyvfaIoQLDEpYYF6kpvYqEjw2fHBHaVFrC7x1I='; script-src 'none';">
     <style>
       html {
         font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
@@ -82,11 +82,37 @@
       .vscode-dark code {
         background-color: #4b4b4b;
       }
+
+      details > summary {
+        list-style: none;
+        position: relative;
+        cursor: pointer;
+      }
+      details > summary::marker {
+        display: none;
+      }
+      details > summary::before {
+        content: "▼";
+        font-family: serif;
+        position: absolute;
+        left: 0;
+        top: 40%;
+        transform: translate(0, -50%) rotate(-90deg);
+      }
+      details[open] > summary:before {
+        transform: translate(0, -50%) rotate(0);
+      }
+      details > summary > * {
+        padding-left: 1.5rem;
+      }
     </style>
   </head>
   <body>
     <h1>Extension Updates</h1>
+<details open>
+  <summary>
 <h2>My Extension 1 <code>ID_1</code></h2>
+  </summary>
 <h3>[1.0.0]</h3>
 <h4>Added</h4>
 <ul>
@@ -97,7 +123,11 @@
 <ul>
 <li>Introduced &quot;foo&quot; option</li>
 </ul>
+</details>
+<details open>
+  <summary>
 <h2>My Extension 2 <code>ID_2</code></h2>
+  </summary>
 <h3>[1.0.0]</h3>
 <h4>Added</h4>
 <ul>
@@ -107,7 +137,11 @@
 <ul>
 <li>Configuration &quot;bar&quot;</li>
 </ul>
+</details>
+<details open>
+  <summary>
 <h2>My Extension 3 <code>ID_3</code></h2>
+  </summary>
 <h3>[0.12.1]</h3>
 <ul>
 <li>foo</li>
@@ -116,6 +150,7 @@
 <ul>
 <li>bar</li>
 </ul>
+</details>
 
   </body>
 </html>


### PR DESCRIPTION
Implement collapsible sections / details.

This allows big changelogs, where versions cannot be parsed correctly, to be collapsed. 
Giving easier access to the next extension changelog, without having to scroll for long time.

Support for collapsible sections / details are not implemented in `markdown-it`: https://github.com/markdown-it/markdown-it/issues/510#issuecomment-434395177

There is a plugin available: https://github.com/Bioruebe/markdown-it-collapsible#readme
But those sections are by default collapsed. Default open support is not implemented: https://github.com/Bioruebe/markdown-it-collapsible/issues/1#issuecomment-1025123101
~~It also appears to not support Markdown within the `summary`.~~ It looks like only **inline** Markdown [is supported](https://github.com/Bioruebe/markdown-it-collapsible/blob/master/index.js#L4) within the `summary`. And headers are considered block-elements instead of inline.

This means I had to activate `commonmark` parser, to allow some HTML tags. This might even be a good thing, because:
> GFM is a strict superset of CommonMark.
https://github.github.com/gfm/#what-is-github-flavored-markdown-

This PR is based on suggestion from #11.

This PR is compatible with #29 (aldo it might create merge-conflicts, which I can easily fix).

All collapsed:
![image](https://user-images.githubusercontent.com/55841/189611651-b1ae2bd5-0d6a-4f38-a2ed-a695e2fe7363.png)

One open:
![image](https://user-images.githubusercontent.com/55841/189611758-5e9b89a6-6d71-440c-a4ac-a368c3b9d676.png)
