### PR TITLE
Improve homepage and add repository links. Fixes #41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add command to show report. Closes [#8](https://github.com/ryu1kn/vscode-extension-update-reporter/issues/8) by @jerone in [PR #38](https://github.com/ryu1kn/vscode-extension-update-reporter/pull/38).
 - Add before and after versions. Closes [#4](https://github.com/ryu1kn/vscode-extension-update-reporter/issues/4) by @jerone in [PR #40](https://github.com/ryu1kn/vscode-extension-update-reporter/pull/40).
 
+### Fixed
+- Improve homepage and add repository links. Fixes [#41](https://github.com/ryu1kn/vscode-extension-update-reporter/issues/41) by @jerone in [PR #42](https://github.com/ryu1kn/vscode-extension-update-reporter/pull/42).
+
 ## [1.2.0] - 2022-11-06
 ### Added
 - Marketplace, extension homepage links are always available for easier access to the full information. (thanks to @jerone [PR #29](https://github.com/ryu1kn/vscode-extension-update-reporter/issues/29))

--- a/package.json
+++ b/package.json
@@ -61,10 +61,12 @@
   },
   "dependencies": {
     "fp-ts": "2.12.3",
+    "hosted-git-info": "^6.1.1",
     "markdown-it": "13.0.1",
     "multiline-string": "1.1.0"
   },
   "devDependencies": {
+    "@types/hosted-git-info": "^3.0.2",
     "@types/markdown-it": "^12.2.3",
     "@types/mocha": "^9.1.1",
     "@types/node": "^16.11.58",

--- a/src/lib/markdown-report-builder.ts
+++ b/src/lib/markdown-report-builder.ts
@@ -69,6 +69,9 @@ export default class MarkdownReportBuilder {
     if (extension.homepage) {
       links.push(`[Homepage](${extension.homepage})`);
     }
+    if (extension.repository) {
+      links.push(`[Repository](${extension.repository})`);
+    }
     return links.join(' ● ');
   }
 

--- a/src/test/helpers/changelog-data.ts
+++ b/src/test/helpers/changelog-data.ts
@@ -37,7 +37,12 @@ export const INVALID_VERSION_FORMAT = multiline(`
 export const INVALID_HEADING = multiline(`
     ### 1.3.0
     * foo
-    
+
     ### Fixes:
     * bar
+    `);
+
+export const VALID_3 = multiline(`
+    ### 1.3.0
+    * foo
     `);

--- a/src/test/lib/extension.test.ts
+++ b/src/test/lib/extension.test.ts
@@ -4,17 +4,65 @@ import {RawExtension} from '../../lib/entities/extension';
 import * as vscode from 'vscode';
 
 describe('Extension', () => {
-  it('uses displayName as its name', () => {
-    const extension = createExtension({ displayName: 'foo', name: 'bar' });
+  it('uses `displayName` as its name', () => {
+    const extension = createExtension({
+      displayName: 'foo',
+      name: 'bar' });
     assert.strictEqual(extension.displayName, 'foo');
   });
 
-  it('uses name as its name if displayName is not available', () => {
-    const extension = createExtension({ name: 'bar' });
+  it('uses `name` as its name if `displayName` is not available', () => {
+    const extension = createExtension({
+      name: 'bar' });
     assert.strictEqual(extension.displayName, 'bar');
   });
 
-  function createExtension (packageJson: {name: string, displayName?: string}) {
+  it('uses `homepage` as its homepage', () => {
+    const extension = createExtension({
+      homepage: 'foo',
+      links: { getstarted: { uri: 'bar' }},
+      repository: 'https://github.com/ryu1kn/vscode-extension-update-reporter.git' });
+    assert.strictEqual(extension.homepage, 'foo');
+  });
+
+  it('uses `links.getstarted.uri` as its homepage when `homepage` is not available', () => {
+    const extension = createExtension({
+      links: { getstarted: { uri: 'foo' }},
+      repository: 'https://github.com/ryu1kn/vscode-extension-update-reporter.git'});
+    assert.strictEqual(extension.homepage, 'foo');
+  });
+
+  it('uses `repository` as its homepage when `homepage` and `links.getstarted.uri` is not available', () => {
+    const extension = createExtension({
+      repository: 'https://github.com/ryu1kn/vscode-extension-update-reporter.git' });
+    assert.strictEqual(extension.homepage, 'https://github.com/ryu1kn/vscode-extension-update-reporter#readme');
+  });
+
+  it('uses `repository` string as its repository', () => {
+    ['https://github.com/ryu1kn/vscode-extension-update-reporter.git',
+     'git+https://github.com/ryu1kn/vscode-extension-update-reporter.git',
+     'git+ssh://git@github.com/ryu1kn/vscode-extension-update-reporter.git'
+    ].forEach((repository) => {
+      const extension = createExtension({
+        repository });
+      assert.strictEqual(extension.repository, 'https://github.com/ryu1kn/vscode-extension-update-reporter.git');
+    });
+  });
+
+  it('uses `repository` object as its repository', () => {
+    ['https://github.com/ryu1kn/vscode-extension-update-reporter.git',
+     'git+https://github.com/ryu1kn/vscode-extension-update-reporter.git',
+     'git+ssh://git@github.com/ryu1kn/vscode-extension-update-reporter.git'
+    ].forEach((repository) => {
+      const extension = createExtension({
+        repository: {
+          url: repository
+      }});
+      assert.strictEqual(extension.repository, 'https://github.com/ryu1kn/vscode-extension-update-reporter.git');
+    });
+  });
+
+  function createExtension (packageJson: any) {
     const rawExtension = {
       packageJSON: packageJson
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -243,6 +243,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/hosted-git-info@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/hosted-git-info/-/hosted-git-info-3.0.2.tgz#aa671076f5edefa4fab1189b467e6c63987be818"
+  integrity sha512-RURNTeEFUwF+ifnp7kK3WLLlTmBSlRynLNS9jeAsI6RHtSrupV0l0nO6kmpaz75EUJVexy348bR452SvmH98vQ==
+
 "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
@@ -1112,6 +1117,13 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+hosted-git-info@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-6.1.1.tgz#629442c7889a69c05de604d52996b74fe6f26d58"
+  integrity sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==
+  dependencies:
+    lru-cache "^7.5.1"
+
 html-escaper@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.0.tgz#71e87f931de3fe09e56661ab9a29aadec707b491"
@@ -1403,6 +1415,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lru-cache@^7.5.1:
+  version "7.14.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.1.tgz#8da8d2f5f59827edb388e63e459ac23d6d408fea"
+  integrity sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==
 
 make-dir@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
- Improve homepage url detection.
- Add link to repository.

This will make it much more in sync with the Marketplace.

Fixes #41

Before:
![](https://user-images.githubusercontent.com/55841/201395206-4ba91dcf-7e36-4b15-b73a-0bbe93e9996e.png)
After:
![image](https://user-images.githubusercontent.com/55841/201430647-8bf33cb3-7559-463f-b368-a7d7c708d4c7.png)

I used the [VSCode extension documentation](https://code.visualstudio.com/api/references/extension-manifest#marketplace-presentation-tips) and the [source code of vsce](https://github.com/microsoft/vscode-vsce/blob/main/src/package.ts) as a reference how the Marketplace is populating it's information.

Therefor this PR introduces a new dependency [`hosted-git-info`](https://www.npmjs.com/package/hosted-git-info) (owned by npm) to account for the different ways the repository url can be written. It will normalize the repository object for both the repository link and as a backup for the homepage link.

I've seen at least the following different examples of `repository` entity in `package.json`:
```
{type: 'git', url: 'https://github.com/microsoft/vscode-remote-repositories-github.git'}
{type: 'git', url: 'git+https://github.com/microsoft/vscode-test-adapter-converter.git'}
{type: 'git', url: 'https://github.com/mrmlnc/vscode-scss'}
{url: 'https://github.com/MicrosoftDocs/intellicode'}
https://github.com/nhoizey/vscode-gremlins.git
{type: 'git', url: 'https://gitlab.com/txava/vscode-region-marker.git'}
```