### PR TITLE
Fix recommended development extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,6 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846
 	// for the documentation about the extensions.json format
 	"recommendations": [
-		"eg2.tslint"
+		"dbaeumer.vscode-eslint"
 	]
 }


### PR DESCRIPTION
VSCode keeps TSLint recommending to install. This was replaced by ESLint some time ago.